### PR TITLE
CON-4414: Audit API documentation has been updated to include info on events/ path query strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ $ make preview
 
 ## Testing
 
+To run these tests you will need to be sure to have [Summon](https://github.com/cyberark/summon) installed, as well as a summon provider. A convenient provider to use for these tests is the [Conjur](https://github.com/cyberark/summon-conjur) provider.
+
+In addition to installing Summon and a valid provider, you'll need to set the `SUMMON_PROVIDER` environment variable (e.g. to `summon-conjur` if you select that as your summon provider) and you may need to run `export CONJUR_MAJOR_VERSION=4`.
+
 Tests are run with [dredd](http://dredd.readthedocs.org/en/latest/) in a Docker container against a Conjur appliance
 also running in Docker.
 

--- a/src/api.md
+++ b/src/api.md
@@ -265,12 +265,17 @@ They are partitioned by "kind", such as "group", "host", "file", "environment", 
 
 Every privilege modification, variable retrieval and SSH action is logged to an immutable audit trail in Conjur.
 
-Audit records can be retrieved via the API for everything or a single role/resource.
-Fetching all audit records can return a very large response, so it is best to the the `limit` parameter.
+You can use the API to retrieve all audit records, to retrieve audit records for a single role or resource, or to retrieve audit records for a set of roles and/or resources.
+
+By default, the number of audit records returned is limited to 100, but this can be adjusted using the `limit` parameter. The maximum number of audit records returned is limited to 10,000.
+
+The number of audit records returned may also be limited using the `till` or `since` parameters, which filter the results returned based on timestamp.
 
 :[audit.all](audit.all.md)
 
 :[audit.single](audit.single.md)
+
+:[audit.multiple](audit.multiple.md)
 
 # Group Utilities
 

--- a/src/audit.all.md
+++ b/src/audit.all.md
@@ -1,4 +1,4 @@
-## All [/api/audit]
+## All [/api/audit{?limit,till,since}]
 
 ### Fetch all audit events [GET]
 
@@ -17,11 +17,17 @@ The example shows a single audit event returned.
 |Code|Description|
 |----|-----------|
 |200|JSON list of audit events is returned|
+|401|Unauthorized|
 |403|Permission denied|
+
++ Parameters
+    + limit: `10` (number, optional) - Maximum number of results to return
+    + till: `2017-11-03T17:00:00.000Z` (string, optional) - Upper time bound for returned events (non-inclusive, in UTC)
+    + since: `2017-11-03T17:00:00.000Z` (string, optional) - Lower time bound for returned events (inclusive, in UTC)
 
 + Request (application/json)
     + Headers
-    
+
         ```
         Authorization: Token token="eyJkYX...Rhb="
         Accept: */*
@@ -33,7 +39,7 @@ The example shows a single audit event returned.
     [
       {
         "resources":[
-    
+
         ],
         "roles":[
           "cucumber:user:admin"

--- a/src/audit.multiple.md
+++ b/src/audit.multiple.md
@@ -1,10 +1,14 @@
-## Single Role or Resource [/api/audit/{kind}/{id}{?limit,till,since}]
+## Multiple Roles or Resources [/api/audit/events{?role[]*,resource[]*,event_action,kind,limit,till,since}]
 
-### Fetch audit events for a single role or resource [GET]
+### Fetch audit events matching any subset of roles or resources [GET]
 
-Fetch audit events for a role/resource the calling identity has `read` privilege on.
+Fetch audit events matching any of a set of roles and/or resources the calling identity has `read` privilege on.
 
-`id` must be query-escaped: `/` -> `%2F`, `:` -> `%3A`.
+If the calling identity does not have `read` privilege on *all* roles and resources
+sent with the request, the API will return a `404 Not Found` response.
+
+
+The `role` and `resource` ID-values must be query-escaped: `/` -> `%2F`, `:` -> `%3A`.
 
 ---
 
@@ -22,8 +26,10 @@ Fetch audit events for a role/resource the calling identity has `read` privilege
 |404|Role/resource not found / request refused|
 
 + Parameters
-    + kind: `roles` (string) - Type of object, 'roles' or 'resources'
-    + id: `cucumber:host:redis001` (string) - Fully qualified ID of a Conjur role/resource, query-escaped
+    + role: `cucumber:host:redis001` (string, optional) - One or more fully qualified IDs of a Conjur role, query-escaped
+    + resource: `cucumber:group:sys_admins` (string, optional) - One or more fully qualified IDs of a Conjur resource, query escaped
+    + event_action: `create` (string, optional) - Event action
+    + kind: `role` (string, optional) - Object class impacted by event
     + limit: `10` (number, optional) - Maximum number of results to return
     + till: `2017-11-03T17:00:00.000Z` (string, optional) - Upper time bound for returned events (non-inclusive, in UTC)
     + since: `2017-11-03T17:00:00.000Z` (string, optional) - Lower time bound for returned events (inclusive, in UTC)

--- a/src/audit.multiple.md
+++ b/src/audit.multiple.md
@@ -1,4 +1,4 @@
-## Multiple Roles or Resources [/api/audit/events{?role[]*,resource[]*,event_action,kind,limit,till,since}]
+## Multiple Roles or Resources [/api/audit/events{?role%5B%5D,resource%5B%5D,event_action,kind,limit,till,since}]
 
 ### Fetch audit events matching any subset of roles or resources [GET]
 
@@ -26,8 +26,8 @@ The `role` and `resource` ID-values must be query-escaped: `/` -> `%2F`, `:` -> 
 |404|Role/resource not found / permission denied|
 
 + Parameters
-    + role: `cucumber:host:redis001` (string, optional) - One or more fully qualified IDs of a Conjur role, query-escaped
-    + resource: `cucumber:group:sys_admins` (string, optional) - One or more fully qualified IDs of a Conjur resource, query escaped
+    + role%5B%5D: `cucumber:host:redis001` (string, optional) - The fully qualified IDs of a Conjur role, query-escaped. Can be used multiple times.
+    + resource%5B%5D: `cucumber:group:sys_admins` (string, optional) - The fully qualified IDs of a Conjur resource, query escaped. Can be used multiple times.
     + event_action: `create` (string, optional) - Event action
     + kind: `role` (string, optional) - Object class impacted by event
     + limit: `10` (number, optional) - Maximum number of results to return

--- a/src/audit.multiple.md
+++ b/src/audit.multiple.md
@@ -27,7 +27,7 @@ The `role` and `resource` ID-values must be query-escaped: `/` -> `%2F`, `:` -> 
 
 + Parameters
     + role%5B%5D: `cucumber:host:redis001` (string, optional) - The fully qualified IDs of a Conjur role, query-escaped. Can be used multiple times.
-    + resource%5B%5D: `cucumber:group:sys_admins` (string, optional) - The fully qualified IDs of a Conjur resource, query escaped. Can be used multiple times.
+    + resource%5B%5D: `cucumber:group:security_admin` (string, optional) - The fully qualified IDs of a Conjur resource, query escaped. Can be used multiple times.
     + event_action: `create` (string, optional) - Event action
     + kind: `role` (string, optional) - Object class impacted by event
     + limit: `10` (number, optional) - Maximum number of results to return

--- a/src/audit.multiple.md
+++ b/src/audit.multiple.md
@@ -23,7 +23,7 @@ The `role` and `resource` ID-values must be query-escaped: `/` -> `%2F`, `:` -> 
 |200|JSON list of audit events is returned|
 |401|Unauthorized|
 |403|Permission denied|
-|404|Role/resource not found / request refused|
+|404|Role/resource not found / permission denied|
 
 + Parameters
     + role: `cucumber:host:redis001` (string, optional) - One or more fully qualified IDs of a Conjur role, query-escaped

--- a/src/audit.single.md
+++ b/src/audit.single.md
@@ -19,7 +19,7 @@ Fetch audit events for a role/resource the calling identity has `read` privilege
 |200|JSON list of audit events is returned|
 |401|Unauthorized|
 |403|Permission denied|
-|404|Role/resource not found / request refused|
+|404|Role/resource not found / permission denied|
 
 + Parameters
     + kind: `roles` (string) - Type of object, 'roles' or 'resources'

--- a/transactions-4.5.txt
+++ b/transactions-4.5.txt
@@ -56,4 +56,5 @@ Resource > Deny > Deny a privilege on a resource
 Resource > Check > Check your own permissions
 Resource > Check > Check another role's permissions
 Audit > All > Fetch all audit events
-Audit > Single > Fetch audit events for a single role/resource
+Audit > Single Role or Resource > Fetch audit events for a single role or resource
+Audit > Multiple Roles or Resources > Fetch audit events matching any subset of roles or resources


### PR DESCRIPTION
closes CON-4414

updating audit documentation to:
- include info on limit/since/till
- add documentation for events/ path with query string
- update 404 error to be `not found / permission denied` since we sometimes return this error for a permissions issue