### PR TITLE
CON-4427 - Apiary docs have been updated to fix broken link to variable expiration info	

### DIFF
--- a/src/variable.set_expiration.md
+++ b/src/variable.set_expiration.md
@@ -18,7 +18,7 @@ For example, "P3Y6M4DT12H30M5S" represents a duration of "three years, six month
 If `duration` is not provided, or if the length of `duration` is zero (`P0Y`),
 the variable will expire immediately.
 
-[read more on expiration](https://developer.conjur.net/tutorials/secrets/expiring-secrets.html)
+[read more on expiration](https://developer.conjur.net/cli#variable-expiration)
 
 ---
 


### PR DESCRIPTION
Resolves [CON-4427](https://conjurinc.atlassian.net/browse/CON-4427)

Quick fix of broken link. If reviewer has suggestions for adding a test to ensure this link doesn't get re-broken (maybe by verifying a curl request to the link URL doesn't return a 500 error?) within the dredd framework, I'll be happy to implement.