### PR TITLE
updating Jenkinsfile to use pipeline library

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -34,14 +34,7 @@ pipeline {
 
   post {
     always {
-      sh 'docker run -i --rm -v $PWD:/src -w /src alpine/git clean -fxd'
-      deleteDir()  // clear workspace, for next run
-    }
-    failure {
-      slackSend(color: 'danger', message: "${env.JOB_NAME} #${env.BUILD_NUMBER} FAILURE (<${env.BUILD_URL}|Open>)")
-    }
-    unstable {
-      slackSend(color: 'warning', message: "${env.JOB_NAME} #${env.BUILD_NUMBER} UNSTABLE (<${env.BUILD_URL}|Open>)")
+      cleanupAndNotify(currentBuild.currentResult)
     }
   }
 }


### PR DESCRIPTION
This PR replaces the old `post` section of the Jenkinsfile with the standardized `post` section in [the Jenkins pipeline library](https://github.com/conjurinc/jenkins-pipeline-library/blob/master/vars/cleanupAndNotify.groovy) in the interest of keeping things DRY. 

Jenkins build currently processing [here](https://jenkins.conjur.net/job/conjurinc--apidocs/job/update-Jenkinsfile-post/)